### PR TITLE
#7 add a commmand to return active connection

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,11 @@
 				"title": "Neo4j: Add Connection"
 			},
 			{
+				"command": "neo4j.getActiveConnection",
+				"enablement": "false",
+				"title": "Neo4j: Get active Connection"
+			},
+			{
 				"command": "neo4j.addAuraConnection",
 				"title": "Neo4j: Add Aura Connection"
 			},

--- a/src/commands/connections/index.ts
+++ b/src/commands/connections/index.ts
@@ -22,6 +22,10 @@ export function connectionSubscriptions(
     window.registerTreeDataProvider(
       "neo4j.connections",
       connections.getTreeProvider()
+    ),
+    commands.registerCommand(
+      'neo4j.getActiveConnection',
+      () => connections.getActive()
     )
   )
 


### PR DESCRIPTION
## Usage
```ts
export interface Neo4jVscodeConenction {
  scheme: string;
  host: string;
  port: string;
  database: string;
  username: string;
  password: string;
}

// Caller place
const neo4jExtension = vscode.extensions.getExtension("adamcowley.neo4j-vscode");
(!neo4jExtension?.isActive ? neo4jExtension?.activate() : Promise.resolve())?.then(() =>
vscode.commands.executeCommand<Neo4jVscodeConenction>("neo4j.getActiveConnection")).then(connection => {
    console.log(`${connection.scheme}://${connection.host}:${connection.port}`);
});
```

## Reference
- [vscode-extension-samples/lsp-sample](https://github.com/microsoft/vscode-extension-samples/blob/main/lsp-sample/client/src/test/helper.ts#L19)